### PR TITLE
Update the state when suite finishes

### DIFF
--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -247,6 +247,7 @@ async function setup() {
 			}
 		} finally {
 			ws.close();
+			suite = null;
 		}
 	});
 


### PR DESCRIPTION
We could not perform 2 test runs in a raw without restarting the core
because of the missing state update when suite is completed.
Before the change, the state was updated from /stop handler only.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>