### PR TITLE
Fail fast when dbus connection cannot be established

### DIFF
--- a/worker/lib/workers/nm.ts
+++ b/worker/lib/workers/nm.ts
@@ -35,7 +35,6 @@ class NetworkManager {
 			wireless: new Teardown(),
 		},
 	) {
-		this.bus.on('error', console.error);
 		// Cleanup code
 		process.on('SIGINT', this.teardown);
 		process.on('SIGTERM', this.teardown);
@@ -88,35 +87,43 @@ class NetworkManager {
 	}
 
 	private async addConnection(connection: any): Promise<string> {
-		const con = (await this.bus.getProxyObject(
-			'org.freedesktop.NetworkManager',
-			'/org/freedesktop/NetworkManager/Settings',
-		)).getInterface('org.freedesktop.NetworkManager.Settings');
+		const con = (
+			await this.bus.getProxyObject(
+				'org.freedesktop.NetworkManager',
+				'/org/freedesktop/NetworkManager/Settings',
+			)
+		).getInterface('org.freedesktop.NetworkManager.Settings');
 
 		return con.AddConnectionUnsaved(connection);
 	}
 
 	private async removeConnection(reference: Connection): Promise<void> {
-		const nodes = (await this.bus.getProxyObject(
-			'org.freedesktop.NetworkManager',
-			'/org/freedesktop/NetworkManager/Settings',
-		)).nodes;
+		const nodes = (
+			await this.bus.getProxyObject(
+				'org.freedesktop.NetworkManager',
+				'/org/freedesktop/NetworkManager/Settings',
+			)
+		).nodes;
 
 		if (nodes.includes(reference)) {
-			const con = (await this.bus.getProxyObject(
-				'org.freedesktop.NetworkManager',
-				reference,
-			)).getInterface('org.freedesktop.NetworkManager.Settings.Connection');
+			const con = (
+				await this.bus.getProxyObject(
+					'org.freedesktop.NetworkManager',
+					reference,
+				)
+			).getInterface('org.freedesktop.NetworkManager.Settings.Connection');
 
 			await con.Delete();
 		}
 	}
 
 	private async getDevice(iface: string): Promise<string> {
-		const con = (await this.bus.getProxyObject(
-			'org.freedesktop.NetworkManager',
-			'/org/freedesktop/NetworkManager',
-		)).getInterface('org.freedesktop.NetworkManager');
+		const con = (
+			await this.bus.getProxyObject(
+				'org.freedesktop.NetworkManager',
+				'/org/freedesktop/NetworkManager',
+			)
+		).getInterface('org.freedesktop.NetworkManager');
 
 		return con.GetDeviceByIpIface(iface);
 	}
@@ -125,10 +132,12 @@ class NetworkManager {
 		reference: Connection,
 		device: string,
 	): Promise<string> {
-		const con = (await this.bus.getProxyObject(
-			'org.freedesktop.NetworkManager',
-			'/org/freedesktop/NetworkManager',
-		)).getInterface('org.freedesktop.NetworkManager');
+		const con = (
+			await this.bus.getProxyObject(
+				'org.freedesktop.NetworkManager',
+				'/org/freedesktop/NetworkManager',
+			)
+		).getInterface('org.freedesktop.NetworkManager');
 
 		return con.ActivateConnection(reference, device, '/');
 	}
@@ -136,16 +145,20 @@ class NetworkManager {
 	private async deactivateConnection(
 		reference: ActiveConnection,
 	): Promise<void> {
-		const nodes = (await this.bus.getProxyObject(
-			'org.freedesktop.NetworkManager',
-			'/org/freedesktop/NetworkManager/ActiveConnection',
-		)).nodes;
+		const nodes = (
+			await this.bus.getProxyObject(
+				'org.freedesktop.NetworkManager',
+				'/org/freedesktop/NetworkManager/ActiveConnection',
+			)
+		).nodes;
 
 		if (nodes.includes(reference)) {
-			const con = (await this.bus.getProxyObject(
-				'org.freedesktop.NetworkManager',
-				'/org/freedesktop/NetworkManager',
-			)).getInterface('org.freedesktop.NetworkManager');
+			const con = (
+				await this.bus.getProxyObject(
+					'org.freedesktop.NetworkManager',
+					'/org/freedesktop/NetworkManager',
+				)
+			).getInterface('org.freedesktop.NetworkManager');
 
 			await con.DeactivateConnection(reference);
 		}


### PR DESCRIPTION
A quick fix to ensure we fail fast if DBUS connection cannot be
initialized. Previously the test was hanging in this case.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>