### PR TITLE
Fix flash error processing

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -56,7 +56,7 @@ module.exports = class Worker {
 
 			let lastStatus;
 			req.on('data', data => {
-				const computedLine = RegExp('(.*): (.*)').exec(data.toString());
+				const computedLine = RegExp('(.+?): (.*)').exec(data.toString());
 
 				if (computedLine) {
 					if (computedLine[1] === 'error') {


### PR DESCRIPTION
Regeexp is changed to a greedy one to handle lines like

        error: ENOENT: not such file or directory

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>