### PR TITLE
Dockerize client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules/
+client/
+workspace/

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ node_modules
 build
 coverage
 .nyc*
-Dockerfile
 
-// Leviathan specific ignores
-client/bin/*.log
-client/bin/*.conf
+# Docker compose file is generated with make, as well as core/worker Dockerfile.
+core/Dockerfile
+worker/Dockerfile

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,5 @@
+bin/*.gz
+bin/config.js
+bin/*.log
+
+node_modules

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,3 @@
+bin/*.gz
+bin/config.js
+bin/*.log

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12
+WORKDIR /usr/src/app
+
+COPY package* ./
+RUN npm ci
+
+COPY config ./config
+COPY lib ./lib
+COPY bin ./bin
+
+VOLUME /usr/src/app/workspace
+
+ENTRYPOINT ["node", "bin/multi-client", "-c", "../workspace/config"]

--- a/client/bin/multi-client.default.conf
+++ b/client/bin/multi-client.default.conf
@@ -1,10 +1,9 @@
 module.exports = {
     deviceType: '<device-type>',
-    suite: `<path-to-suite>`,
+    suite: `${__dirname}/../../suites/os`,
     config: {
-        networkWired: true,
+        networkWired: false,
         networkWireless: true,
-        workerType: 'testbot_hat',
         downloadType: 'local',
         interactiveTests: false,
         balenaApiKey: process.env.BALENA_CLOUD_API_KEY,

--- a/client/bin/single-client.default.conf
+++ b/client/bin/single-client.default.conf
@@ -1,7 +1,6 @@
 {
     "networkWired": false,
     "networkWireless": true,
-    "workerType": "testbot",
     "downloadType": "local",
     "interactiveTests": false,
     "apiUrl": "balena-cloud.com"

--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -95,6 +95,7 @@ async function setup(): Promise<express.Application> {
 				await worker.network(req.body);
 				res.send('OK');
 			} catch (err) {
+				console.error(err);
 				next(err);
 			}
 		},

--- a/worker/lib/workers/testbot.ts
+++ b/worker/lib/workers/testbot.ts
@@ -147,11 +147,13 @@ abstract class TestBot extends Board implements Leviathan.Worker {
 	public async network(
 		configuration: Supported['configuration'],
 	): Promise<void> {
+		console.log('Start network setup');
 		if (this.networkCtl == null) {
 			throw new Error('Network not configured on this worker. Ignoring...');
 		}
 
 		if (configuration.wireless != null) {
+			console.log('Adding wireless connection...');
 			this.internalState.network = {
 				wireless: await this.networkCtl.addWirelessConnection(
 					configuration.wireless,
@@ -163,6 +165,7 @@ abstract class TestBot extends Board implements Leviathan.Worker {
 		}
 
 		if (configuration.wired != null) {
+			console.log('Adding wired connection...');
 			this.internalState.network = {
 				wired: await this.networkCtl.addWiredConnection(configuration.wired),
 			};
@@ -170,6 +173,7 @@ abstract class TestBot extends Board implements Leviathan.Worker {
 			await this.networkCtl.teardowns.wired.run();
 			this.internalState.network.wired = undefined;
 		}
+		console.log('Network setup completed');
 	}
 
 	/**

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -1,0 +1,4 @@
+*.gz
+*.img
+*.js
+*.conf

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,1 @@
+A workspace directory you can run the test suites from.

--- a/workspace/build-client.sh
+++ b/workspace/build-client.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd ../client
+
+docker build -t leviathan .

--- a/workspace/run-tests.sh
+++ b/workspace/run-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+img_name=leviathan
+
+if [ -n "$REBUILD_CLIENT" ] || ! docker inspect $img_name >/dev/null 2>/dev/null; then
+  ./build-client.sh || exit 1
+fi
+
+ws_mount=$(pwd):/usr/src/app/workspace:ro
+suites_mount=$(pwd)/../suites:/usr/src/app/suites:ro
+
+docker run --rm -v $ws_mount -v $suites_mount --name $img_name-suite $img_name -n


### PR DESCRIPTION
Allows running the client as a docker container.
Also, introduces the workspace directory that should be used for local/dev runs.

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>