### PR TITLE
Disable boot-splash test

### DIFF
--- a/suites/os/suite.js
+++ b/suites/os/suite.js
@@ -98,7 +98,8 @@ module.exports = {
 		'./tests/fingerprint',
 		'./tests/led',
 		'./tests/config-json',
-		'./tests/boot-splash',
+		// The boot splash test is currently disabled because of the excessive time spent on it.
+		// './tests/boot-splash',
 		'./tests/connectivity',
 	],
 };


### PR DESCRIPTION
We need to review this test implementation and think if there is a more efficient way to do it.
Also, an ability to run short/long tests would be helpful.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>